### PR TITLE
Don't "test" declarations in these tests

### DIFF
--- a/tests/simple-exec/0033-comma.c
+++ b/tests/simple-exec/0033-comma.c
@@ -14,6 +14,7 @@ bar()
 	return 2;
 }
 
+int
 main()
 {
 	int v;

--- a/tests/simple-exec/0034-comma.c
+++ b/tests/simple-exec/0034-comma.c
@@ -14,6 +14,7 @@ bar()
 	return 2;
 }
 
+int
 main()
 {
 	int v;

--- a/tests/simple-exec/0074-misc.c
+++ b/tests/simple-exec/0074-misc.c
@@ -1,7 +1,11 @@
+void
 abort();
+
+int
 main() {
   int b;
   b = 1080377166;
   if (b != 1080377166)
     abort();
+  return 0;
 }


### PR DESCRIPTION
Unless we think there's an interesting interplay between
declarations and other things in these tests, don't "test"
declarations here.

Old-style declarations (with identifier lists and implicit int)
deserve separate tests.